### PR TITLE
Add Laravel 13.x support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['8.4', '8.5']
-                laravel: [12.*]
+                laravel: [12.*, 13.*]
 
         steps:
             - name: Checkout Code
@@ -79,9 +79,9 @@ jobs:
               run: composer test-ci
 
             - name: Upload coverage to Codecov
-              if: matrix.php == '8.5' && matrix.laravel == '12.*'
+              if: matrix.php == '8.5' && matrix.laravel == '13.*'
               uses: codecov/codecov-action@v5
 
             - name: Upload test results to Codecov
-              if: matrix.php == '8.5' && matrix.laravel == '12.*'
+              if: matrix.php == '8.5' && matrix.laravel == '13.*'
               uses: codecov/test-results-action@v1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/aporat/laravel-filter-var.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-filter-var)
 [![Downloads](https://img.shields.io/packagist/dt/aporat/laravel-filter-var.svg?style=flat-square&logo=composer)](https://packagist.org/packages/aporat/laravel-filter-var)
 [![Codecov](https://img.shields.io/codecov/c/github/aporat/laravel-filter-var?style=flat-square)](https://codecov.io/github/aporat/laravel-filter-var)
-[![Laravel Version](https://img.shields.io/badge/Laravel-12.x-orange.svg?style=flat-square)](https://laravel.com/docs/12.x)
+[![Laravel Version](https://img.shields.io/badge/Laravel-12.x%20|%2013.x-orange.svg?style=flat-square)](https://laravel.com/docs/13.x)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/aporat/laravel-filter-var/ci.yml?style=flat-square)
 [![License](https://img.shields.io/packagist/l/aporat/laravel-filter-var.svg?style=flat-square)](https://github.com/aporat/laravel-filter-var/blob/master/LICENSE)
 
@@ -17,7 +17,7 @@ A Laravel package for filtering and sanitizing request variables with a chainabl
 
 ## Requirements
 - **PHP**: 8.4 or higher
-- **Laravel**: 10.x, 11.x or 12.x
+- **Laravel**: 12.x or 13.x
 - **Composer**: Required for installation
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/support": "^12.0",
+        "illuminate/support": "^12.0 || ^13.0",
         "nesbot/carbon": "^2.72 || ^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^12.0"
     },


### PR DESCRIPTION
## Summary
This PR adds support for Laravel 13.x while maintaining compatibility with Laravel 12.x.

## Key Changes
- Updated `composer.json` to allow `illuminate/support` ^13.0 in addition to ^12.0
- Updated `orchestra/testbench` to support ^11.0 for Laravel 13.x testing
- Extended CI/CD pipeline to test against both Laravel 12.x and 13.x with PHP 8.4 and 8.5
- Updated codecov upload conditions to use Laravel 13.x as the reference version
- Updated README.md to reflect support for both Laravel 12.x and 13.x versions
- Updated requirements documentation to show Laravel 12.x and 13.x as supported versions

## Implementation Details
- The package now maintains a dual-version support strategy, allowing it to work with both Laravel 12.x and 13.x
- CI matrix expanded to test all combinations of PHP 8.4/8.5 with Laravel 12.x/13.x
- Codecov uploads now reference Laravel 13.x with PHP 8.5 as the canonical test configuration

https://claude.ai/code/session_017dykstAqCdRKteDPMkDh69